### PR TITLE
Check for permissions when inserting new readings.

### DIFF
--- a/sensehat/rest.php
+++ b/sensehat/rest.php
@@ -10,6 +10,9 @@ class BiabSenseHAT_REST {
 		register_rest_route( 'biab/v1', '/sensehat', array(
 			'methods' => 'POST',
 			'callback' => array( 'BiabSensehat_REST', 'insert_reading' ),
+			'permission_callback' => function() {
+				return current_user_can( 'edit_others_posts' );
+			},
 		) );
 	}
 


### PR DESCRIPTION
The capability 'edit_others_posts' is associated to editors and admins.